### PR TITLE
Fixes missing string on some compilers

### DIFF
--- a/src/PaContext.h
+++ b/src/PaContext.h
@@ -19,6 +19,7 @@
 #include "node_api.h"
 #include <memory>
 #include <mutex>
+#include <string>
 
 struct PaStreamParameters;
 


### PR DESCRIPTION
This fixes the compilation on some systems where string is not exposed.

```
npm ERR! In file included from ../src/PaContext.cc:16:
npm ERR! ../src/PaContext.h:65:15: error: field ‘mErrStr’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
```