### PR TITLE
Remove segfault handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,6 @@
 const { Readable, Writable, Duplex } = require('stream');
 const portAudioBindings = require("bindings")("naudiodon.node");
 
-var SegfaultHandler = require('segfault-handler');
-SegfaultHandler.registerHandler("crash.log");
-
 exports.SampleFormatFloat32 = 1;
 exports.SampleFormat8Bit = 8;
 exports.SampleFormat16Bit = 16;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,15 +27,6 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
-    "segfault-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
-      "integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
-      "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.14.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "url": "git+https://github.com/csukuangfj/naudiodon2.git"
   },
   "dependencies": {
-    "bindings": "^1.5.0",
-    "segfault-handler": "^1.3.0"
+    "bindings": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^16.11.7"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Streampunk Media Ltd",
   "license": "Apache-2.0",
   "scripts": {
-    "install": "node-gyp rebuild"
+    "rebuild": "node-gyp rebuild"
   },
-  "gypfile": true
+  "gypfile": false
 }

--- a/src/PaContext.h
+++ b/src/PaContext.h
@@ -19,6 +19,7 @@
 #include "node_api.h"
 #include <memory>
 #include <mutex>
+#include <string>
 
 struct PaStreamParameters;
 


### PR DESCRIPTION
The segfault-handler causes issue with some windows machines when some dlls unrelated to this project are not available. Segfault handler also can not run inside of electron backend, only node. If users need the functionality of segfault handler, they can add it to their own projects, with no loss of data. I think it is simplest and best if it is not a dependency of this project.